### PR TITLE
chore: add repository-wide .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# Node modules
+node_modules/
+
+# Build outputs
+build/
+dist/
+*.log
+
+# .NET build artifacts
+bin/
+obj/
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Additional .NET artifacts
+*.suo
+*.user
+*.csproj.user
+*.sln.docstates
+
+# Coverage and logs
+coverage/
+logs/
+
+# Environment files
+.env


### PR DESCRIPTION
## Summary
- add root-level .gitignore for node modules, build outputs, .NET artifacts, logs, coverage, and env files

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa7558d0832b9bfa5c7d172db293